### PR TITLE
Added support for XIA hosts in Mininet

### DIFF
--- a/bin/mn
+++ b/bin/mn
@@ -24,9 +24,9 @@ from mininet.clean import cleanup
 import mininet.cli
 from mininet.log import lg, LEVELS, info, debug, warn, error, output
 from mininet.net import Mininet, MininetWithControlNet, VERSION
-from mininet.node import ( Host, CPULimitedHost, Controller, OVSController,
-                           Ryu, NOX, RemoteController, findController,
-                           DefaultController, NullController,
+from mininet.node import ( Host, CPULimitedHost, XIAHost, Controller,
+                           OVSController, Ryu, NOX, RemoteController,
+                           findController, DefaultController, NullController,
                            UserSwitch, OVSSwitch, OVSBridge,
                            IVSSwitch )
 from mininet.nodelib import LinuxBridge
@@ -70,7 +70,8 @@ SWITCHES = { 'user': UserSwitch,
 HOSTDEF = 'proc'
 HOSTS = { 'proc': Host,
           'rt': specialClass( CPULimitedHost, defaults=dict( sched='rt' ) ),
-          'cfs': specialClass( CPULimitedHost, defaults=dict( sched='cfs' ) ) }
+          'cfs': specialClass( CPULimitedHost, defaults=dict( sched='cfs' ) ),
+          'xia': XIAHost }
 
 CONTROLLERDEF = 'default'
 CONTROLLERS = { 'ref': Controller,

--- a/examples/README.md
+++ b/examples/README.md
@@ -177,3 +177,17 @@ connectivity using `ping`, for different switch/datapath types.
 
 An example of how to subclass Host to use a VLAN on its primary interface.
 
+#### xiaecho.py:
+
+This example sets up a topology with 2 nodes, pre-configured with
+XIA Host Identifiers to test the XIA net-echo application.
+
+#### xiatunnel.py:
+
+The example creates a network for testing the communication
+of XIA hosts over an existing ipv4 network. The U4ID principal creates
+UDP sockets that carry the XIP packet as UDP/IP payload.
+
+#### xiazFilter.py:
+
+This example tests XIA multicasting with net-echo.

--- a/examples/xiaecho.py
+++ b/examples/xiaecho.py
@@ -1,0 +1,36 @@
+#!/usr/bin/python
+
+"""
+xiaecho.py: test the echo application on two XIA hosts.
+One XIA host acts as the echo server and the other as echo client.
+The client sends a text or a file to the server which is echoed
+back to the client.
+"""
+
+from mininet.log import setLogLevel, info
+from mininet.cli import CLI
+from mininet.net import Mininet
+from mininet.node import XIAHost
+
+def topology():
+    "A topology for net-echo experiment"
+
+    net = Mininet( controller=None )
+
+    info( "*** creating nodes\n" )
+    xia1 = net.addHost( 'xia1', cls=XIAHost, hid=[ 'xia1_hid1' ], xdp=True )
+    xia2 = net.addHost( 'xia2', cls=XIAHost, hid=[ 'xia2_hid1' ], xdp=True )
+
+    info("*** creating links\n")
+    net.addLink( xia1, xia2 )
+
+    info( "*** starting network \n" )
+    net.build()
+    CLI( net )
+
+    info( "*** stopping network\n" )
+    net.stop()
+
+if __name__ == '__main__':
+    setLogLevel( 'info' )
+    topology()

--- a/examples/xiatunnel.py
+++ b/examples/xiatunnel.py
@@ -1,0 +1,71 @@
+#!/usr/bin/python
+
+"""
+xiatunnel.py: an example to test XIA-IP compatibility
+"""
+
+from mininet.net import Mininet
+from mininet.node import Host, XIAHost
+from mininet.nodelib import LinuxBridge
+from mininet.log import setLogLevel, info
+from mininet.cli import CLI
+
+# From mininet/examples/linuxrouter.py
+
+class LinuxRouter( Host ):
+    "A Node with IP forwarding enabled."
+
+    def config( self, **params ):
+        super( LinuxRouter, self).config( **params )
+        self.cmd( 'sysctl net.ipv4.ip_forward=1' )
+
+    def terminate( self ):
+        self.cmd( 'sysctl net.ipv4.ip_forward=0' )
+        super( LinuxRouter, self ).terminate()
+
+def xiatunnel():
+    "Starts a topology to demonstrate co-existence of TCP/IP and XIA"
+    xia1_u4id = { 'ipaddr': '172.16.0.2', 'port': '0x52a3', 'tunnel': True }
+    xia3_u4id = { 'ipaddr': '192.168.100.2', 'port': '0x52a1', 'tunnel': True }
+    net = Mininet( controller=None )
+    info( '*** Adding hosts\n' )
+    # Start the Routers
+    r1 = net.addHost( 'r1', cls=LinuxRouter, ip='172.16.0.1/16' )
+    r2 = net.addHost( 'r2', cls=LinuxRouter, ip='192.168.100.1/24' )
+    # Start the XIA hosts
+    xia1 = net.addHost( 'xia1', cls=XIAHost, ip='172.16.0.2/16',
+                        defaultRoute='via 172.16.0.1', u4id=xia1_u4id,
+                        xdp=True, hid=[ 'xia1_hid1' ] )
+    xia2 = net.addHost( 'xia2', cls=XIAHost, ip='172.16.0.3/16',
+                        defaultRoute='via 172.16.0.1',
+                        lpm=[ '172.16.0.0/16' ] )
+    xia3 = net.addHost( 'xia3', cls=XIAHost, ip='192.168.100.2/24',
+                        defaultRoute='via 192.168.100.1', u4id=xia3_u4id,
+                        xdp=True, hid=[ 'xia3_hid1' ] )
+
+    info( '*** Adding switches\n' )
+    br1 = net.addSwitch( 'br1', cls=LinuxBridge )
+    br2 = net.addSwitch( 'br2', cls=LinuxBridge )
+
+    info( '*** Adding links\n' )
+    net.addLink( br1, r1, params2={ 'ip': '172.16.0.1/16' } )
+    net.addLink( br2, r2, params2={ 'ip': '192.168.100.1/24' } )
+    net.addLink( r1, r2, params1={ 'ip': '10.0.0.1/8' },
+                 params2={ 'ip': '10.0.0.2/8' } )
+    for s, d in [ ( xia1, br1 ), ( xia2, br1 ), ( xia3, br2 ) ]:
+        net.addLink( s, d )
+
+    # Configure the static routes
+    r1.cmd( 'ip route add 192.168.100.0/24 via 10.0.0.2 src 10.0.0.1' )
+    r2.cmd( 'ip route add 172.16.0.0/16 via 10.0.0.1 src 10.0.0.2' )
+
+    info( '*** Starting network\n')
+    net.start()
+    CLI( net )
+
+    info( '*** Stopping network' )
+    net.stop()
+
+if __name__ == '__main__':
+    setLogLevel( 'info' )
+    xiatunnel()

--- a/examples/xiazFilter.py
+++ b/examples/xiazFilter.py
@@ -1,0 +1,47 @@
+#!/usr/bin/python
+
+"""
+xiazFilter.py: This example tests XIA multicasting with net-echo.
+"""
+
+from mininet.nodelib import LinuxBridge
+from mininet.node import XIAHost
+from mininet.net import Mininet
+from mininet.cli import CLI
+from mininet.log import setLogLevel, info
+
+
+def zFilter():
+    "The zFilter topology"
+
+    net = Mininet()
+
+    # zFilter ID for xia2
+    zf = [ '0100000000000000000000000000000000000000' ]
+
+    info( '*** Adding hosts\n' )
+    xia1 = net.addHost( 'xia1' , cls=XIAHost, hid=[ 'xia1_hid1' ], xdp=True )
+    xia2 = net.addHost( 'xia2' , cls=XIAHost, hid=[ 'xia2_hid1' ], zfid=zf,
+                        xdp=True )
+    xia3 = net.addHost( 'xia3' , cls=XIAHost, hid=[ 'xia3_hid1' ] )
+
+    info( '*** Adding switch\n' )
+    br1 = net.addSwitch( 'br1', cls=LinuxBridge )
+
+    info( '*** Adding links\n' )
+    net.addLink( xia1, br1 )
+    net.addLink( xia2, br1 )
+    net.addLink( xia3, br1 )
+
+    info( '*** Starting network\n' )
+    net.start()
+
+    info( '*** Running CLI\n' )
+    CLI( net )
+
+    info( '*** Stopping network' )
+    net.stop()
+
+if __name__ == '__main__':
+    setLogLevel( 'info' )
+    zFilter()

--- a/mininet/link.py
+++ b/mininet/link.py
@@ -68,6 +68,10 @@ class Intf( object ):
         "Configure ourselves using ifconfig"
         return self.cmd( 'ifconfig', self.name, *args )
 
+    def xip( self, *args ):
+        "Configure the interface with XIDs"
+        return self.cmd( 'xip', *args )
+
     def setIP( self, ipstr, prefixLen=None ):
         """Set our IP address"""
         # This is a sign that we should perhaps rethink our prefix
@@ -92,6 +96,12 @@ class Intf( object ):
 
     _ipMatchRegex = re.compile( r'\d+\.\d+\.\d+\.\d+' )
     _macMatchRegex = re.compile( r'..:..:..:..:..:..' )
+
+    def setEthID( self ):
+        """Set the ether ID for the interface.
+           The ether principal is the only
+           interface bound principal of XIA so far."""
+        return self.xip( 'ether', 'addif', '%s-%s' % ( self.node, self.name ) )
 
     def updateIP( self ):
         "Return updated IP address based on ifconfig"


### PR DESCRIPTION
**Add configuration options for [eXpressive Internet Architecture](http://www.cs.cmu.edu/~xia/)(XIA):**
XIA  principals covered include: HID, AD, LPM, Ether, U4ID and zFilter. 

This feature of Mininet will enable testing XIA a lot easier than it presently is using Linux Containers.